### PR TITLE
Fix of visual bug on learning feature and plan pop up page

### DIFF
--- a/client/src/pages/Workouts/Workouts.css
+++ b/client/src/pages/Workouts/Workouts.css
@@ -29,8 +29,7 @@
   transform-style: preserve-3d;
 }
 
-
-.card {
+.container card {
   width: 100%;
   background: #fff;
   color: #333;
@@ -45,30 +44,7 @@
 .card.back {
   background: #f4f4f4;
   transform: rotateY(180deg);
-}
-
-.card-image {
-  width: 100%;
-  /* Same width as flip cards */
-  height: 80%;
-  /* Fixed height for images */
-  object-fit: cover;
-  /* Ensure images cover the area without distortion */
-  margin-bottom: 10px;
-  /* Add space between image and text */
-}
-
-.card-image {
-  width: 100%;
-  /* Same width as flip cards */
-  height: 80%;
-  /* Fixed height for images */
-  object-fit: cover;
-  /* Ensure images cover the area without distortion */
-  margin-bottom: 10px;
-  /* Add space between image and text */
-  margin-bottom: 10px;
-  /* Add space between image and text */
+  backface-visibility: hidden;
 }
 
 .card-image {
@@ -82,44 +58,4 @@
   /* Add space between image and text */
   margin-bottom: 10px;
   /* Add space between image and text */
-}
-
-
-.card-image {
-  width: 100%;
-  /* Same width as flip cards */
-  height: 80%;
-  /* Fixed height for images */
-  object-fit: cover;
-  /* Ensure images cover the area without distortion */
-  margin-bottom: 10px;
-  /* Add space between image and text */
-  margin-bottom: 10px;
-  /* Add space between image and text */
-}
-
-.card-image {
-  width: 100%;
-  /* Same width as flip cards */
-  height: 80%;
-  /* Fixed height for images */
-  object-fit: cover;
-  /* Ensure images cover the area without distortion */
-  margin-bottom: 10px;
-  /* Add space between image and text */
-  margin-bottom: 10px;
-
-  /* Add space between image and text */
-  .card-image {
-    width: 100%;
-    /* Same width as flip cards */
-    height: 80%;
-    /* Fixed height for images */
-    object-fit: cover;
-    /* Ensure images cover the area without distortion */
-    margin-bottom: 10px;
-    /* Add space between image and text */
-    margin-bottom: 10px;
-    /* Add space between image and text */
-  }
 }


### PR DESCRIPTION
Plan pop up cards and content on social page was experiencing a visual error due to a css tag in workouts.css overriding a default tag of bootstrap's. 

workouts.css had a tag named .card which was overriding bootstrap's .card tag. After reducing the scope of .card to a container in workouts.js the visual bug stopped occurring on both pages.  